### PR TITLE
v0.6

### DIFF
--- a/javascripts/discourse/lib/klipper-jinja2_highlight.js
+++ b/javascripts/discourse/lib/klipper-jinja2_highlight.js
@@ -86,7 +86,7 @@ export default function (hljs) {
 
   return {
     name: "Klipper Config",
-    aliases: ["klipper", "cfg"],
+    aliases: ["kcfg", "kmacro"],
     disableAutodetect: true,
     contains: [
       COMMENT,


### PR DESCRIPTION
Rename the language options to 'kcfg' and / or 'kmacro' also to avoid clashing with potentially other highlighter languages